### PR TITLE
Trying to learn by sticking my nose where it don't belong

### DIFF
--- a/core/Data/Path/Types.hs
+++ b/core/Data/Path/Types.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE DataKinds, GADTs, KindSignatures, LambdaCase, RankNTypes, StandaloneDeriving, TypeOperators,
-             UndecidableInstances #-}
+{-# LANGUAGE DataKinds, GADTs, KindSignatures, LambdaCase, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 
 module Data.Path.Types
     ( -- * Core types

--- a/empathy.cabal
+++ b/empathy.cabal
@@ -1,4 +1,4 @@
-cabal-version:       2.4
+cabal-version:       3.0
 name:                empathy
 version:             0.1.0.0
 synopsis:            typed paths, with feeling
@@ -14,6 +14,7 @@ build-type:          Simple
 extra-doc-files:     README.md
                    , CHANGELOG.md
 tested-with:         GHC == 8.6.4
+                   , GHC == 8.8.1
 
 source-repository head
   type:                git
@@ -33,7 +34,6 @@ common shared
 
   build-depends:       base >= 4.10 && < 4.15
                      , megaparsec ^>= 7.0.5
-
 
 library empathy-core
   import:              shared
@@ -71,14 +71,11 @@ library
     build-depends:     empathy-posix
     mixins:            empathy-sig (Data.Path.Generic as Data.Path) requires (Data.Path.System as Data.Path.System.Posix)
 
-
-
 test-suite empathy-test
   import:              shared
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
-
   build-depends:       base
                      , empathy
                      , tasty ^>= 1.2.3

--- a/sig/Data/Path/Generic.hs
+++ b/sig/Data/Path/Generic.hs
@@ -111,7 +111,12 @@ parse = first P.errorBundlePretty . P.parse (parser <* P.eof) ""
 
 -- | Convert a 'Path' to a String, suitable for being passed as a @FilePath@ from @System.FilePath@.
 toString :: Path ar fd -> String
-toString p = T.fold mempty (showChar pathSeparator) showString (\a b -> a <> showChar pathSeparator <> b) p ""
+toString p = T.fold mempty (showChar pathSeparator) showString comb p ""
+  where
+    comb :: ShowS -> ShowS -> ShowS
+    comb a b
+      | a "" == [pathSeparator] = a <> b
+      | otherwise               = a <> showChar pathSeparator <> b
 
 -- | An eliminator for absolute or relative paths, ignoring entity type.
 chooseAbsRel :: forall ar fd a . AbsRel ar

--- a/sig/Data/Path/Generic.hs
+++ b/sig/Data/Path/Generic.hs
@@ -111,12 +111,10 @@ parse = first P.errorBundlePretty . P.parse (parser <* P.eof) ""
 
 -- | Convert a 'Path' to a String, suitable for being passed as a @FilePath@ from @System.FilePath@.
 toString :: Path ar fd -> String
-toString p = T.fold mempty (showChar pathSeparator) showString comb p ""
+toString p = finish $ T.fold mempty (showChar pathSeparator) showString comb p ""
   where
-    comb :: ShowS -> ShowS -> ShowS
-    comb a b
-      | a "" == [pathSeparator] = a <> b
-      | otherwise               = a <> showChar pathSeparator <> b
+    comb a b = a <> showChar pathSeparator <> b
+    finish   = (pathSeparator :) . dropWhile (== pathSeparator)
 
 -- | An eliminator for absolute or relative paths, ignoring entity type.
 chooseAbsRel :: forall ar fd a . AbsRel ar


### PR DESCRIPTION
Hi!

First of all, thanks for making this library. I've been looking for a chance to learn backpack and more advanced type system magic, and this provided a great opportunity.

Second, _please_ feel free to ignore/cherrypick/whatever from this PR. The only changes I made were

- slight tweaks to the `cabal` file to reflect my testing it with 8.8.1
- removing an unused `LANGUAGE` pragma from `Types.hs` (viz. `RankNTypes`)
- removing two unused `LANGUAGE` pragmas (viz. `RankNTypes` and `LambdaCase`), being more explicit with/removing unused imports, and making some adjustments suggested by `hlint` to `Generic.hs`

Finally, one question if you have the time (totally fine if not!): I've tried doing some round-trip usage of `parse` and `toString`, and can't seem to get it to work using `rootDir </> relDir @"tmp"`, as the comments on `relDir` suggest. However, `currentDir </> relDir @"tmp"` seems to work. Am I misunderstanding how to use the code here? Is this an error in `toString`?

Thanks again for your time and library!

```haskell
~/github/empathy ∃ cabal repl empathy                                                                                                                                      master
Build profile: -w ghc-8.8.1 -O1
In order, the following will be built (use -v for more details):
 - empathy-0.1.0.0 (lib) (file /Users/graham/github/empathy/dist-newstyle/build/x86_64-osx/ghc-8.8.1/empathy-0.1.0.0/l/empathy-sig/empathy-0.1.0.0-inplace-empathy-sig+DWs2WEJmzrS86LoSL3csHn/cache/build changed)
Preprocessing library for empathy-0.1.0.0..
Warning: No exposed modules
GHCi, version 8.8.1: https://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /Users/graham/github/dotfiles/ghci
λ⋙ :set -XDataKinds
λ⋙ :set -XTypeApplications
λ⋙ import Data.Path
λ⋙ either error id . parse @'Abs @'Dir . toString $ rootDir </> relDir @"tmp"
*** Exception: 1:2:
  |
1 | //tmp
  |  ^
unexpected '/'
expecting end of input

CallStack (from HasCallStack):
  error, called at <interactive>:4:8 in interactive:Ghci1
λ⋙ either error id . parse @'Abs @'Dir . toString $ currentDir  </> relDir @"tmp"
Combine Root (Comp "tmp")
it :: Path 'Abs 'Dir
λ⋙ toString $ currentDir </> relDir @"tmp"
"/tmp"
it :: String
λ⋙ toString $ rootDir </> relDir @"tmp"
"//tmp"
it :: String
```